### PR TITLE
[#ICC-232] Add MessageStatus ChangeFeed for Reminder

### DIFF
--- a/CosmosApiMessageStatusChangeFeedForReminder/__tests__/handler.test.ts
+++ b/CosmosApiMessageStatusChangeFeedForReminder/__tests__/handler.test.ts
@@ -1,0 +1,70 @@
+import { pipe } from "fp-ts/lib/function";
+import { aMessageStatus } from "../../__mocks__/message";
+import { handleAvroMessageStatusPublishChange as handler } from "../handler";
+import * as RA from "fp-ts/ReadonlyArray";
+import { RetrievedMessageStatus } from "@pagopa/io-functions-commons/dist/src/models/message_status";
+import { toAvroMessageStatus } from "../../utils/formatter/messageStatusAvroFormatter";
+import { MessageStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageStatusValue";
+
+// ----------------------
+// Variables
+// ----------------------
+
+const topic = "aTopic";
+
+const aListOfMessageStatus = pipe(
+  Array.from({ length: 10 }, i => aMessageStatus)
+);
+
+const getExpectedMessageStatusBuffer = (
+  messageStatuses: RetrievedMessageStatus[]
+) => pipe(messageStatuses, RA.fromArray, RA.map(toAvroMessageStatus));
+
+// ----------------------
+// Mocks
+// ----------------------
+
+const mockContext = {
+  bindings: {},
+  done: jest.fn()
+} as any;
+
+// ----------------------
+// Tests
+// ----------------------
+
+describe("CosmosApiMessageStatusChangeFeedForReminder", () => {
+  beforeEach(() => jest.clearAllMocks());
+  it("should send all retrieved message status", async () => {
+    await handler(mockContext, aListOfMessageStatus);
+
+    expect(mockContext.bindings["outputMessageStatus"]).toEqual(
+      getExpectedMessageStatusBuffer(aListOfMessageStatus)
+    );
+    expect(mockContext.done).toHaveBeenCalled();
+  });
+
+  it("should send only retrieved message status that can be decoded", async () => {
+    await handler(mockContext, [
+      { ...aMessageStatus, status: "WRONG_STATUS" },
+      ...aListOfMessageStatus
+    ]);
+
+    expect(mockContext.bindings["outputMessageStatus"]).toEqual(
+      getExpectedMessageStatusBuffer(aListOfMessageStatus)
+    );
+    expect(mockContext.done).toHaveBeenCalled();
+  });
+
+  it("should send only PROCESSED retrieved message status", async () => {
+    await handler(mockContext, [
+      { ...aMessageStatus, status: MessageStatusValueEnum.REJECTED },
+      ...aListOfMessageStatus
+    ]);
+
+    expect(mockContext.bindings["outputMessageStatus"]).toEqual(
+      getExpectedMessageStatusBuffer(aListOfMessageStatus)
+    );
+    expect(mockContext.done).toHaveBeenCalled();
+  });
+});

--- a/CosmosApiMessageStatusChangeFeedForReminder/__tests__/handler.test.ts
+++ b/CosmosApiMessageStatusChangeFeedForReminder/__tests__/handler.test.ts
@@ -24,17 +24,21 @@ const getExpectedMessageStatusBuffer = (
 // Mocks
 // ----------------------
 
-const mockContext = {
-  bindings: {},
-  done: jest.fn()
-} as any;
+const mockContext = { bindings: {}, done: jest.fn() } as any;
+
+const resetBindings = () => {
+  mockContext.bindings = {};
+};
 
 // ----------------------
 // Tests
 // ----------------------
 
 describe("CosmosApiMessageStatusChangeFeedForReminder", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetBindings();
+  });
   it("should send all retrieved message status", async () => {
     await handler(mockContext, aListOfMessageStatus);
 

--- a/CosmosApiMessageStatusChangeFeedForReminder/__tests__/handler.test.ts
+++ b/CosmosApiMessageStatusChangeFeedForReminder/__tests__/handler.test.ts
@@ -67,4 +67,13 @@ describe("CosmosApiMessageStatusChangeFeedForReminder", () => {
     );
     expect(mockContext.done).toHaveBeenCalled();
   });
+
+  it("should populate output bindings only if PROCESSED retrieved message status array is not empty", async () => {
+    await handler(mockContext, [
+      { ...aMessageStatus, status: MessageStatusValueEnum.REJECTED }
+    ]);
+
+    expect(mockContext.bindings["outputMessageStatus"]).toBeUndefined();
+    expect(mockContext.done).toHaveBeenCalled();
+  });
 });

--- a/CosmosApiMessageStatusChangeFeedForReminder/function.json
+++ b/CosmosApiMessageStatusChangeFeedForReminder/function.json
@@ -21,5 +21,10 @@
       "direction": "out"
     }
   ],
+  "retry": {
+    "strategy": "fixedDelay",
+    "maxRetryCount": -1,
+    "delayInterval": "00:00:10"
+  },
   "scriptFile": "../dist/CosmosApiMessageStatusChangeFeedForReminder/index.js"
 }

--- a/CosmosApiMessageStatusChangeFeedForReminder/function.json
+++ b/CosmosApiMessageStatusChangeFeedForReminder/function.json
@@ -1,0 +1,25 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "cosmosDBTrigger",
+      "name": "cosmosApiMessageStatusTrigger",
+      "direction": "in",
+      "connectionStringSetting": "COSMOSDB_CONNECTION_STRING",
+      "databaseName": "%COSMOSDB_NAME%",
+      "collectionName": "message-status",
+      "leaseCollectionName": "cqrs-leases",
+      "leaseCollectionPrefix": "CosmosApiMessageStatusChangeFeedForReminder",
+      "createLeaseCollectionIfNotExists": true,
+      "startFromBeginning": false
+    },
+    {
+      "type": "eventHub",
+      "name": "outputMessageStatus",
+      "eventHubName": "%MESSAGE_STATUS_FOR_REMINDER_TOPIC_NAME%",
+      "connection": "MESSAGE_STATUS_FOR_REMINDER_TOPIC_PRODUCER_CONNECTION_STRING",
+      "direction": "out"
+    }
+  ],
+  "scriptFile": "../dist/CosmosApiMessageStatusChangeFeedForReminder/index.js"
+}

--- a/CosmosApiMessageStatusChangeFeedForReminder/handler.ts
+++ b/CosmosApiMessageStatusChangeFeedForReminder/handler.ts
@@ -1,0 +1,23 @@
+import { Context } from "@azure/functions";
+import { RetrievedMessageStatus } from "@pagopa/io-functions-commons/dist/src/models/message_status";
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+import { MessageStatusValueEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageStatusValue";
+import { toAvroMessageStatus } from "../utils/formatter/messageStatusAvroFormatter";
+
+export const handleAvroMessageStatusPublishChange = async (
+  context: Context,
+  rawMessageStatus: ReadonlyArray<unknown>
+): Promise<void> => {
+  // eslint-disable-next-line functional/immutable-data
+  context.bindings.outputMessageStatus = pipe(
+    rawMessageStatus,
+    RA.map(RetrievedMessageStatus.decode),
+    RA.rights,
+    RA.filter(
+      messageStatus => messageStatus.status === MessageStatusValueEnum.PROCESSED
+    ),
+    RA.map(toAvroMessageStatus)
+  );
+  context.done();
+};

--- a/CosmosApiMessageStatusChangeFeedForReminder/index.ts
+++ b/CosmosApiMessageStatusChangeFeedForReminder/index.ts
@@ -1,0 +1,21 @@
+import * as winston from "winston";
+import { Context } from "@azure/functions";
+import { AzureContextTransport } from "@pagopa/io-functions-commons/dist/src/utils/logging";
+import { handleAvroMessageStatusPublishChange } from "./handler";
+
+// eslint-disable-next-line functional/no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+const run = async (
+  context: Context,
+  rawMessageStatus: ReadonlyArray<unknown>
+): Promise<void> => {
+  logger = context.log;
+  return handleAvroMessageStatusPublishChange(context, rawMessageStatus);
+};
+
+export default run;

--- a/CosmosApiMessageStatusChangeFeedForView/function.json
+++ b/CosmosApiMessageStatusChangeFeedForView/function.json
@@ -22,7 +22,9 @@
     }
   ],
   "retry": {
-    "maxRetryCount": -1
+    "strategy": "fixedDelay",
+    "maxRetryCount": -1,
+    "delayInterval": "00:00:10"
   },
   "scriptFile": "../dist/CosmosApiMessageStatusChangeFeedForView/index.js"
 }

--- a/CosmosApiMessageStatusChangeFeedForView/function.json
+++ b/CosmosApiMessageStatusChangeFeedForView/function.json
@@ -21,5 +21,8 @@
       "direction": "out"
     }
   ],
+  "retry": {
+    "maxRetryCount": -1
+  },
   "scriptFile": "../dist/CosmosApiMessageStatusChangeFeedForView/index.js"
 }

--- a/HandleMessageChangeFeedPublishFailures/__tests__/handler.test.ts
+++ b/HandleMessageChangeFeedPublishFailures/__tests__/handler.test.ts
@@ -75,13 +75,11 @@ describe("HandleMessageChangeFeedPublishFailureHandler", () => {
     expect(res).toEqual(void 0);
     expect(telemetryClientMock.trackException).not.toHaveBeenCalled();
     expect(functionsContextMock.bindings.messages).toEqual(
-      JSON.stringify(
-        avroMessageFormatter(aMessageCategoryFetcher)({
-          ...inputMessage.body,
-          content: aMessageContent,
-          kind: "IRetrievedMessageWithContent"
-        })
-      )
+      avroMessageFormatter(aMessageCategoryFetcher)({
+        ...inputMessage.body,
+        content: aMessageContent,
+        kind: "IRetrievedMessageWithContent"
+      }).value
     );
   });
 

--- a/HandleMessageChangeFeedPublishFailures/handler.ts
+++ b/HandleMessageChangeFeedPublishFailures/handler.ts
@@ -75,15 +75,11 @@ export const HandleMessageChangeFeedPublishFailureHandler = (
       )
     ),
     TE.map(
-      flow(
-        avroMessageFormatter(categoryFetcher),
-        JSON.stringify,
-        avroMessage => {
-          // eslint-disable-next-line functional/immutable-data
-          context.bindings.messages = avroMessage;
-          context.done();
-        }
-      )
+      flow(avroMessageFormatter(categoryFetcher), avroMessage => {
+        // eslint-disable-next-line functional/immutable-data
+        context.bindings.messages = avroMessage.value;
+        context.done();
+      })
     ),
     TE.mapLeft(err => {
       const isTransient = TransientFailure.is(err);

--- a/avro/message-status.json
+++ b/avro/message-status.json
@@ -1,0 +1,45 @@
+{
+  "name": "messageStatus",
+  "type": "record",
+  "namespace": "dto",
+  "doc": "Kafka JS schema for cosmos api container 'message-status'",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "default": "undefined"
+    },
+    {
+      "name": "messageId",
+      "type": "string",
+      "default": "undefined"
+    },
+    {
+      "name": "updatedAt",
+      "type": "long",
+      "logicalType": "timestamp-millis",
+      "default": 0
+    },
+    {
+      "name": "version",
+      "type": "int",
+      "default": 0
+    },
+    {
+      "name": "isRead",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "name": "isArchived",
+      "type": "boolean",
+      "default": false
+    },
+    {
+      "name": "timestamp",
+      "type": "long",
+      "logicalType": "timestamp-millis",
+      "default": 0
+    }
+  ]
+}

--- a/utils/formatter/messageStatusAvroFormatter.ts
+++ b/utils/formatter/messageStatusAvroFormatter.ts
@@ -32,6 +32,6 @@ export const toAvroMessageStatus = (messageStatus: RetrievedMessageStatus) =>
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const avroMessageStatusFormatter = (): MessageFormatter<RetrievedMessageStatus> => messageStatus => ({
-  key: messageStatus.id,
+  key: messageStatus.messageId,
   value: toAvroMessageStatus(messageStatus)
 });

--- a/utils/formatter/messageStatusAvroFormatter.ts
+++ b/utils/formatter/messageStatusAvroFormatter.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as avro from "avsc";
+
+import { MessageFormatter } from "@pagopa/fp-ts-kafkajs/dist/lib/KafkaTypes";
+import { RetrievedMessageStatus } from "@pagopa/io-functions-commons/dist/src/models/message_status";
+import { messageStatus as avroMessage } from "../../generated/avro/dto/messageStatus";
+
+export const buildAvroMessageStatusObject = (
+  retrievedMessageStatus: RetrievedMessageStatus
+): Omit<avroMessage, "schema" | "subject"> => ({
+  id: retrievedMessageStatus.id,
+  isArchived: retrievedMessageStatus.isArchived,
+  isRead: retrievedMessageStatus.isRead,
+  messageId: retrievedMessageStatus.messageId,
+  // eslint-disable-next-line no-underscore-dangle
+  timestamp: retrievedMessageStatus._ts * 1000,
+  updatedAt: retrievedMessageStatus.updatedAt.getTime(),
+  version: retrievedMessageStatus.version
+});
+
+export const toAvroMessageStatus = (messageStatus: RetrievedMessageStatus) =>
+  avro.Type.forSchema(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    avroMessage.schema as avro.Schema // cast due to tsc can not proper recognize object as avro.Schema (eg. if you use const schemaServices: avro.Type = JSON.parse(JSON.stringify(services.schema())); it will loose the object type and it will work fine)
+  ).toBuffer(
+    Object.assign(
+      new avroMessage(),
+      buildAvroMessageStatusObject(messageStatus)
+    )
+  );
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const avroMessageStatusFormatter = (): MessageFormatter<RetrievedMessageStatus> => messageStatus => ({
+  key: messageStatus.id,
+  value: toAvroMessageStatus(messageStatus)
+});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Add `CosmosApiMessageStatusChangeFeedForReminder` handler
- Add `messageStatusAvroFormatter`
- Add `message-status` avro schema
- Add tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This handler is required by Reminder in order to know status change on citizen's messages, such as readStatus.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
